### PR TITLE
remove walrus operator for python 3.7 compatibility

### DIFF
--- a/apiclient_pydantic/serializers.py
+++ b/apiclient_pydantic/serializers.py
@@ -46,7 +46,8 @@ def serialize_request(schema: Optional[Type[BaseModel]] = None, extra_kwargs: di
         # Override signature
         if parameters:
             sig = inspect.signature(func)
-            self_param = [param] if (param := sig.parameters.get('self')) else []
+            _self_param = sig.parameters.get('self')
+            self_param = [_self_param] if _self_param else []
             sig = sig.replace(parameters=tuple(self_param + parameters))
             wrap.__signature__ = sig
         return wrap


### PR DESCRIPTION
Library is supposed to be compatible with Python 3.7+, I believe the walrus operator has been introduced in Python 3.9. This simple changes removes the operator for compatibility with Python 3.7 and 3.8.